### PR TITLE
Implement overwrite support for upload

### DIFF
--- a/src/s3am/__init__.py
+++ b/src/s3am/__init__.py
@@ -25,10 +25,43 @@ logging.basicConfig( level=logging.WARN,
 
 
 class UserError( Exception ):
-    """
-    An exception that doesn't cause a stack trace to be printed.
-    """
     pass
+
+
+def user_error(status_code):
+    class _UserError( UserError ):
+        """
+        An exception that doesn't cause a stack trace to be printed.
+        """
+        def __init__( self, message ):
+            assert status_code > 0
+            self.status_code = status_code
+            super( UserError, self ).__init__( message )
+    return _UserError
+
+# Error classes that build upon the UserError class.  Each class has a unique exit code.
+ObjectExistsError = user_error( 3 )
+
+
+UploadExistsError = user_error( 4 )
+
+
+InvalidSourceURLError = user_error( 5 )
+
+
+InvalidDestinationURLError = user_error( 6 )
+
+
+InvalidS3URLError = user_error( 7 )
+
+
+InvalidPartSizeError = user_error( 8 )
+
+
+InvalidChecksumAlgorithmError = user_error( 9 )
+
+
+InvalidEncryptionKeyError = user_error( 10 )
 
 
 class WorkerException( Exception ):

--- a/src/s3am/cli.py
+++ b/src/s3am/cli.py
@@ -53,6 +53,7 @@ def main( args ):
             dst_url=o.dst_url,
             resume=o.resume,
             force=o.force,
+            exists=o.exists,
             part_size=o.part_size,
             download_slots=o.download_slots,
             upload_slots=o.upload_slots,
@@ -141,6 +142,13 @@ def parse_args( args ):
                           "uploads for the given object before beginning a new upload. "
                           "Without this flag, s3am will err on the side of caution and "
                           "exit with an error if it detects unfinished uploads." )
+
+    upload_sp.add_argument( '--exists', choices=[ 'overwrite', 'skip', None ],
+                            help="How should s3am procesd if the object at DST_URL already exists?"
+                                 "'overwrite' will overwrite the destination file, 'skip' will "
+                                 "silently skip the upload by exiting with exit code 0. The default"
+                                 " None will exit with non-zero exit code, without modifying the "
+                                 "remote file.", default=None )
 
     defaults = default_args( Upload.__init__ )
 

--- a/src/s3am/cli.py
+++ b/src/s3am/cli.py
@@ -19,7 +19,7 @@ import sys
 import inspect
 import argparse
 
-from s3am import UserError
+from s3am import UserError, InvalidChecksumAlgorithmError
 from s3am.humanize import human2bytes
 from s3am.operations import (min_part_size,
                              max_part_size,
@@ -37,7 +37,7 @@ def try_main( args=sys.argv[ 1: ] ):
         main( args )
     except UserError as e:
         sys.stderr.write( "error: %s\n" % e.message )
-        sys.exit( 2 )
+        sys.exit( e.status_code )
 
 
 def main( args ):
@@ -70,7 +70,8 @@ def main( args ):
         try:
             checksum = hashlib.new( o.checksum )
         except ValueError:
-            raise UserError( "Checksum algorithm '%s' does not exist" % o.checksum )
+            raise InvalidChecksumAlgorithmError( "Checksum algorithm '%s' does not exist" %
+                                                 o.checksum )
         operation = Verify(
             url=o.url,
             checksum=checksum,

--- a/src/s3am/operations.py
+++ b/src/s3am/operations.py
@@ -41,7 +41,19 @@ from boto.s3.connection import S3Connection, xml
 
 from boto.s3.multipart import MultiPartUpload, Part
 
-from s3am import me, log, UserError, WorkerException
+from boto.exception import S3ResponseError
+
+from s3am import (me,
+                  log,
+                  ObjectExistsError,
+                  UploadExistsError,
+                  InvalidSourceURLError,
+                  InvalidDestinationURLError,
+                  InvalidS3URLError,
+                  InvalidPartSizeError,
+                  InvalidEncryptionKeyError,
+                  WorkerException)
+
 from s3am.boto_utils import (work_around_dots_in_bucket_names,
                              s3_connect_to_region,
                              bucket_location_to_region,
@@ -182,7 +194,8 @@ class BucketModification( Operation ):
                 bucket = s3.get_bucket( self.bucket_name, headers=headers )
                 self.bucket_location = self.get_bucket_location( bucket, headers=headers )
         else:
-            raise UserError( 'Destination URL must be of the form s3://BUCKET/ or s3://BUCKET/KEY' )
+            raise InvalidS3URLError( 'Invalid Destination  S3 URL (%s). Must be of the form '
+                                     's3://BUCKET/ or s3://BUCKET/KEY.' % dst_url )
 
     @property
     def bucket_region( self ):
@@ -311,9 +324,10 @@ class Cancel( BucketModification ):
     def __init__( self, dst_url, allow_prefix, **kwargs ):
         super( Cancel, self ).__init__( dst_url, **kwargs )
         if (self.key_name.endswith( '/' ) or self.key_name == '') and not allow_prefix:
-            raise UserError( "Make sure the destination URL does not end in / or pass --prefix if "
-                             "you really intend to delete uploads for all objects whose key starts "
-                             "with '%s'." % self.key_name )
+            raise InvalidDestinationURLError(
+                "Make sure the destination URL does not end in / or pass --prefix if you really "
+                "intend to delete uploads for all objects whose key starts with '%s'." %
+                self.key_name )
         self.allow_prefix = allow_prefix
 
     def run( self ):
@@ -354,11 +368,11 @@ class Upload( BucketModification ):
             src_url = 'file://' + os.path.abspath( src_url )
         parsed_src_url = urlparse( src_url )
         if parsed_src_url.scheme == 'file' and parsed_src_url.netloc not in ('', 'localhost'):
-            raise UserError( 'The URL %s is not a valid file:// URL. For absolute paths use '
-                             'file:/ABSOLUTE/PATH/TO/FILE, file:///ABSOLUTE/PATH/TO/FILE or just '
-                             '/ABSOLUTE/PATH/TO/FILE. For relative paths use '
-                             'RELATIVE/PATH/TO/FILE. To refer to a file called FILE in the current '
-                             'working directory, use FILE.' )
+            raise InvalidSourceURLError( 'The URL %s is not a valid file:// URL. For absolute paths'
+                                         'use file:/ABSOLUTE/PATH/TO/FILE, file:///ABSOLUTE/PATH/TO'
+                                         '/FILE or just /ABSOLUTE/PATH/TO/FILE. For relative paths'
+                                         'use RELATIVE/PATH/TO/FILE. To refer to a file called FILE'
+                                         'in the current working directory, use FILE.' % src_url )
         src_url = parsed_src_url
         if self.key_name.endswith( '/' ) or self.key_name == '':
             self.key_name += os.path.basename( src_url.path )
@@ -494,7 +508,7 @@ class Upload( BucketModification ):
                         if len( completed_parts ) > 0:
                             previous_part_size = self._guess_part_size( completed_parts )
                             if self.part_size != previous_part_size:
-                                raise UserError(
+                                raise InvalidPartSizeError(
                                     "Transfer failed. The part size appears to have changed from "
                                     "%i to %i. Either resume the upload with the previous part "
                                     "size or cancel it before using the new part size." % (
@@ -516,7 +530,7 @@ class Upload( BucketModification ):
                     uploads = [ ]
                 else:
                     if len( uploads ) == 1:
-                        raise UserError(
+                        raise UploadExistsError(
                             "Transfer failed. There is an unfinished upload. To resume that "
                             "upload, run {me} again with --resume. To cancel it, use '{me} cancel "
                             "s3://{bucket_name}/{key_name}'. Note that unfinished uploads incur "
@@ -841,7 +855,8 @@ class Verify( Operation ):
             raise NotImplementedError(
                 "Only 's3' URLs are currently supported, not '%s." % url.scheme )
         if not url.netloc or not url.path.startswith( '/' ):
-            raise UserError( 'An S3 URL must be of the form s3:/BUCKET/ or s3://BUCKET/KEY' )
+            raise InvalidS3URLError( 'Invalid Destination  S3 URL (%s). Must be of the form '
+                                     's3://BUCKET/ or s3://BUCKET/KEY.' % url )
         self.url = url
         self.checksum = checksum
         self.sse_key = sse_key

--- a/src/s3am/test/s3am_tests.py
+++ b/src/s3am/test/s3am_tests.py
@@ -136,7 +136,7 @@ class OperationsTests( unittest.TestCase ):
     def test_invalid_file_urls( self ):
         test_file = self.test_files[ 1 ]
         for url_prefix in ('file:/',):
-            self.assertRaises( s3am.UserError, s3am.cli.main, concat(
+            self.assertRaises( s3am.InvalidSourceURLError, s3am.cli.main, concat(
                 'upload', verbose, slots,
                 url_prefix + test_file.path, self.dst_url( ) ) )
 
@@ -201,8 +201,8 @@ class OperationsTests( unittest.TestCase ):
         # Retrying without --resume should fail
         try:
             s3am.cli.main( concat( 'upload', verbose, slots, src_url, self.dst_url( ) ) )
-        except s3am.UserError as e:
-            self.assertIn( "unfinished upload", e.message )
+        except s3am.UploadExistsError:
+            pass
         else:
             self.fail( )
 
@@ -211,8 +211,8 @@ class OperationsTests( unittest.TestCase ):
             s3am.cli.main( concat(
                 'upload', verbose, slots, src_url, self.dst_url( ),
                 '--resume', '--part-size', str( 2 * part_size ) ) )
-        except s3am.UserError as e:
-            self.assertIn( "part size appears to have changed", e.message )
+        except s3am.InvalidPartSizeError:
+            pass
         else:
             self.fail( )
 
@@ -239,8 +239,8 @@ class OperationsTests( unittest.TestCase ):
         # Retrying without --resume should fail
         try:
             s3am.cli.main( concat( 'upload', verbose, slots, src_url, self.dst_url( ) ) )
-        except s3am.UserError as e:
-            self.assertIn( "unfinished upload", e.message )
+        except s3am.UploadExistsError:
+            pass
         else:
             self.fail( )
 
@@ -266,8 +266,8 @@ class OperationsTests( unittest.TestCase ):
         # A retry without --resume should fail.
         try:
             s3am.cli.main( concat( 'upload', verbose, slots, src_url, self.dst_url( ) ) )
-        except s3am.UserError as e:
-            self.assertIn( "unfinished upload", e.message )
+        except s3am.UploadExistsError:
+            pass
         else:
             self.fail( )
 


### PR DESCRIPTION
 (resolves #30, resolves #46)

If a key already exists in the bucket, then exit with a message saying the file already exists. If the user wants to overwrite the
destination file, they can use the --overwrite flag.
